### PR TITLE
Add XDG-compliant launching method

### DIFF
--- a/pumpkin.sh
+++ b/pumpkin.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PATH=./bin:$PATH
 export LD_LIBRARY_PATH=./bin
-./pumpkin -d 1 -f pumpkin.log -s libscriptlua.so ./script/pumpkin_linux.lua
+"${script_dir}/pumpkin" -d 1 -f pumpkin.log -s libscriptlua.so ./script/pumpkin_linux.lua

--- a/pumpkin_rpi.sh
+++ b/pumpkin_rpi.sh
@@ -1,15 +1,17 @@
+#!/usr/bin/env bash
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PATH=./bin:$PATH
 export LD_LIBRARY_PATH=./bin
 
 add_gpio() {
-  if [ ! -L /sys/class/gpio/gpio$1 ]; then
-    echo $1 > /sys/class/gpio/export
+  if [ ! -L "/sys/class/gpio/gpio$1" ]; then
+    echo "$1" > /sys/class/gpio/export
   fi
 }
 
 del_gpio() {
-  if [ -L /sys/class/gpio/gpio$1 ]; then
-    echo $1 > /sys/class/gpio/unexport
+  if [ -L "/sys/class/gpio/gpio$1" ]; then
+    echo "$1" > /sys/class/gpio/unexport
   fi
 }
 
@@ -18,7 +20,7 @@ add_gpio 25
 echo -e '\033[?17;0;0c' > /dev/tty1
 
 #./pumpkin -d 1 -f pumpkin.log -s libscriptlua.so ./script/pumpkin_linux.lua
-./pumpkin -d 1 -s libscriptlua.so ./script/pumpkin_linux.lua
+"${script_dir}/pumpkin" -d 1 -s libscriptlua.so ./script/pumpkin_linux.lua
 
 del_gpio 24
 del_gpio 25

--- a/pumpkin_xdg.sh
+++ b/pumpkin_xdg.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+LD_LIBRARY_PATH="${script_dir}/bin"
+export LD_LIBRARY_PATH
+storage_dir="${XDG_DATA_HOME:-${HOME}/.local/share}/PumpkinOS"
+mkdir -p "${storage_dir}"
+if ! [ -d "${storage_dir}/vfs" ]; then
+    cp -rf "${script_dir}/vfs" "${storage_dir}"
+fi
+mkdir -p "${storage_dir}/vfs/app_storage" "${storage_dir}/registry" "${storage_dir}/log"
+cd "${storage_dir}" || exit 1
+XDG_PUMPKINOS="${storage_dir}"
+export XDG_PUMPKINOS
+"${script_dir}/pumpkin" -d 1 -f "${storage_dir}/pumpkin.log" -s "${LD_LIBRARY_PATH}/libscriptlua.so" "${script_dir}/script/pumpkin_linux.lua"

--- a/script/pumpkin_linux.lua
+++ b/script/pumpkin_linux.lua
@@ -14,7 +14,13 @@ if not wp then
   return
 end
 
-pit.mount("./vfs/", "/")
+xdg_pumpkin_os = os.getenv("XDG_PUMPKINOS")
+
+if not xdg_pumpkin_os then
+  pit.mount("./vfs/", "/")
+else
+  pit.mount(xdg_pumpkin_os .. "/vfs/", "/")
+end
 
 pumpkin = pit.loadlib("libos")
 pumpkin.init()

--- a/src/duktape/duk.sh
+++ b/src/duktape/duk.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 PATH=../../bin:$PATH
 export LD_LIBRARY_PATH=../../bin
 ./duk "$@"

--- a/src/mk.sh
+++ b/src/mk.sh
@@ -12,18 +12,18 @@ OSNAME=$1
 BITS=$2
 TARGET=$3
 
-DIR=`pwd`
+DIR=$(pwd)
 ROOT=$DIR/..
 PATH=$ROOT/bin:$PATH
-export LD_LIBRARY_PATH=$ROOT/bin
+export LD_LIBRARY_PATH="$ROOT/bin"
 
-if [ $OSNAME = "Msys" ]; then
+if [ "$OSNAME" = "Msys" ]; then
   SDL2=
   GUI=windows
-elif [ $OSNAME = "GNU/Linux" ]; then
+elif [ "$OSNAME" = "GNU/Linux" ]; then
   SDL2=liblsdl2
   GUI=linux
-elif [ $OSNAME = "Serenity" ]; then
+elif [ "$OSNAME" = "Serenity" ]; then
   if [ -z "$SERENITY" ]; then
     echo "Environment variable SERENITY must point to SerenityOS home directory"
     exit 1
@@ -37,27 +37,27 @@ fi
 
 for dir in bin lib tools vfs/app_card/PALM/Programs vfs/app_install vfs/app_storage registry
 do
-  if [ ! -d $ROOT/$dir ]; then
+  if [ ! -d "$ROOT"/$dir ]; then
     echo "creating directory $dir"
-    mkdir -p $ROOT/$dir
+    mkdir -p "$ROOT"/$dir
   fi
 done
 
 for dir in pilrc prcbuild
 do
   if [ -d $dir ]; then
-    cd $dir
-    make ROOT=$ROOT BITS=$BITS $TARGET
-    cd $DIR
+    cd $dir || exit
+    make ROOT="$ROOT" BITS="$BITS" "$TARGET"
+    cd "$DIR" || exit
   fi
 done
 
 for dir in libpit lua $SDL2 libpumpkin libos libshell $GUI BOOT Launcher Preferences Command Edit LuaSyntax MemoPad AddressBook ToDoList DateBook
 do
-  if [ -d $dir ]; then
-    cd $dir
-    make ROOT=$ROOT OSNAME=$OSNAME BITS=$BITS SERENITY=$SERENITY $TARGET
-    cd $DIR
+  if [ -d "$dir" ]; then
+    cd "$dir" || exit
+    make ROOT="$ROOT" OSNAME="$OSNAME" BITS="$BITS" SERENITY="$SERENITY" "$TARGET"
+    cd "$DIR" || exit
   fi
 done
 


### PR DESCRIPTION
- `pumpkin_xdg.sh` will write default VFS data to XDG_DATA_HOME
- `pumpkin_xdg.sh` will set XDG_PUMPKINOS to trigger an alternate path for `/` in `pumpkin_linux.lua`
- Does not copy if it already exists
- Creates other necessary directories: `log`, `registry`